### PR TITLE
Fix your JS-interop example with a little hackery.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # dart-js-interop-toy
 
 Created as an example for [this StackOverflow post](https://stackoverflow.com/questions/41273787/getting-an-arbitrary-property-from-a-javascript-object-in-dart). See [main.dart](https://github.com/ahirschberg/dart-js-interop-toy/blob/master/web/main.dart) for the relevant dart code.
+
+Bug filed: [https://github.com/dart-lang/sdk/issues/28194](https://github.com/dart-lang/sdk/issues/28194)

--- a/web/index.html
+++ b/web/index.html
@@ -5,10 +5,10 @@
         <meta name="viewport" content="width=device-width" />
         <title></title>
         <script src="toy.js"></script>
-        <script type="application/dart" src="main.dart"></script>
-        <script defer src="packages/browser/dart.js"></script>
     </head>
     <body>
         body
+        <script type="application/dart" src="main.dart"></script>
+        <script defer src="packages/browser/dart.js"></script>
     </body>
 </html>

--- a/web/main.dart
+++ b/web/main.dart
@@ -1,7 +1,14 @@
+import 'package:js/js_util.dart';
+
 import 'toy_facade.dart';
+
 main() {
-    // this line gives the error that JsObjectImpl has no accessor [].
-    // I understand why I'm getting that error, but not *how* I can access the
-    // properties of a plain javascript object from dart.
-    print(Toy.getData()["arbitrary_prop"]);
+  // When compiled to JS, this ~roughly means `log(window.toy.getData())` :)
+  // I've also filed https://github.com/dart-lang/sdk/issues/28194 for you.
+  var properties = toy.getData();
+
+  // `getProperty` basically delegates directly to JS.
+  //
+  // See package:js/js_util.dart.
+  print(getProperty(properties, 'arbitrary_prop'));
 }

--- a/web/main.dart
+++ b/web/main.dart
@@ -1,14 +1,8 @@
-import 'package:js/js_util.dart';
-
 import 'toy_facade.dart';
 
 main() {
   // When compiled to JS, this ~roughly means `log(window.toy.getData())` :)
   // I've also filed https://github.com/dart-lang/sdk/issues/28194 for you.
-  var properties = toy.getData();
-
-  // `getProperty` basically delegates directly to JS.
-  //
-  // See package:js/js_util.dart.
-  print(getProperty(properties, 'arbitrary_prop'));
+  var properties = jsToMap(toy.getData());
+  print(properties);
 }

--- a/web/toy.js
+++ b/web/toy.js
@@ -1,5 +1,9 @@
-toy = {
-    getData: function () {
-        return {"arbitrary_prop": "i'm the data"};
+window.toy = (function() {
+  return {
+    getData: function() {
+      return {
+        'arbitrary_prop': 'Woot!'
+      };
     }
-}
+  };
+})();

--- a/web/toy_facade.dart
+++ b/web/toy_facade.dart
@@ -7,19 +7,16 @@ import 'package:js/js_util.dart';
 /// A workaround to converting an object from JS to a Dart Map.
 Map jsToMap(jsObject) {
   return new Map.fromIterable(
-    _objectJsType.keys(jsObject),
+    _getKeysOfObject(jsObject),
     value: (key) => getProperty(jsObject, key),
   );
 }
 
-@JS('Object')
-external _ObjectStatics get _objectJsType;
-
-@JS()
-@anonymous
-abstract class _ObjectStatics {
-  external List<String> keys(jsObject);
-}
+// Both of these interfaces exist to call `Object.keys` from Dart.
+//
+// But you don't use them directly. Just see `jsToMap`.
+@JS('Object.keys')
+external List<String> _getKeysOfObject(jsObject);
 
 // This isn't a real "class" in JavaScript, but an anonymous object.
 //

--- a/web/toy_facade.dart
+++ b/web/toy_facade.dart
@@ -1,9 +1,23 @@
-@JS()
+@JS('window')
 library toy;
 
-import "package:js/js.dart";
+import 'dart:js';
+import 'package:js/js.dart';
 
-@JS("toy")
+// This isn't a real "class" in JavaScript, but an anonymous object.
+//
+// But we <3 static typing.
+//
+// So `@anonymous` means "type doesn't actually exist in the JS".
+@JS()
+@anonymous
 abstract class Toy {
-    external static dynamic getData();
+  @JS()
+  external dynamic getData();
 }
+
+// Access the `window.toy` object exposed via `toy.js`.
+//
+// We get back an "interface" of [Toy].
+@JS('toy')
+external Toy get toy;

--- a/web/toy_facade.dart
+++ b/web/toy_facade.dart
@@ -1,8 +1,25 @@
 @JS('window')
 library toy;
 
-import 'dart:js';
 import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+/// A workaround to converting an object from JS to a Dart Map.
+Map jsToMap(jsObject) {
+  return new Map.fromIterable(
+    _objectJsType.keys(jsObject),
+    value: (key) => getProperty(jsObject, key),
+  );
+}
+
+@JS('Object')
+external _ObjectStatics get _objectJsType;
+
+@JS()
+@anonymous
+abstract class _ObjectStatics {
+  external List<String> keys(jsObject);
+}
 
 // This isn't a real "class" in JavaScript, but an anonymous object.
 //


### PR DESCRIPTION
Introduced a function called `jsToMap`, which creates a `Map` from any JS-interop object.

This actually compiles quite well in `dart2js`. Also filed:

https://github.com/dart-lang/sdk/issues/28194

To get this fixed.